### PR TITLE
improve German translation

### DIFF
--- a/addon/locale/de-DE.properties
+++ b/addon/locale/de-DE.properties
@@ -1,38 +1,38 @@
 addonName_title=Tab Daten
 
 memoryUsageLabel=Speicher
-graphLabel=Karte
-countsLabel=zählen
+graphLabel=Grafik
+countsLabel=Statistik
 settingsLabel=Einstellungen
 
-openNow_title=Offen jetzt:
-openSession_title=während der Sitzung geöffnet:
-openInstall_title=seit Addon eröffnete installieren:
+openNow_title=Momentan geöffnet:
+openSession_title=Während der Sitzung geöffnet:
+openInstall_title=Seit Addon-Installation geöffnet:
 
-behaviour_title=Behaviour
-ui_title=User Interface
+behaviour_title=Verhalten
+ui_title=Benutzeroberfläche
 tasks_title=Aufgaben
 graphType_title=Diagrammtyp
-graphType_options.Line=Zeilen
-graphType_options.Bar=Bar
+graphType_options.Line=Linien
+graphType_options.Bar=Balken
 graphType_options.Radar=Radar
-graphType_options.PolarArea=Polargebiet
+graphType_options.PolarArea=Polar
 
-memoryInterval_title=Wie viele Sekunden zwischen den Speicherdatenerfassung?
-memoryTracking_title=Freigabe Speichernutzung Tracking?
-Speichernutzung memoryUsageOnTabTitlesPref_title=Anzeigen in Tab-Reiter?
-memoryUsageOnTabTitlesPref_options.Prepend=voranstellen
-memoryUsageOnTabTitlesPref_options.Append=anhängen
+memoryInterval_title=Wie viele Sekunden zwischen den Speicherdatenerfassungen?
+memoryTracking_title=Aktiviere Erfassung des Speicherverbrauchs?
+memoryUsageOnTabTitlesPref_title=Anzeigen in Tab-Reitern?
+memoryUsageOnTabTitlesPref_options.Prepend=Voranstellen
+memoryUsageOnTabTitlesPref_options.Append=Anhängen
 memoryUsageOnTabTitlesPref_options.Disable=Deaktivieren
 
-memoryFormat_title=Format der Speichernutzung auf Holz?
+memoryFormat_title=Format der Speichernutzung im Panel?
 memoryFormat_options.JSON=JSON
 memoryFormat_options.Plain=Plain
-
 memoryCautionThreshold_title=Speicher Vorsicht Schwelle? (In MB)
-showUrl_title=Anzeige URL auf die Speichernutzung Platte?
-garbageCollection_title=Führen Sie eine Garbage Collection
-run_title=gehen
 
-panelWidth_title=Breite des Panel-Benutzeroberfläche
-panelHeight_title=Höhe des Panels UI
+showUrl_title=URL im Panel für Speicherverbrauch anzeigen?
+garbageCollection_title=Speicherbereinigung ausführen
+run_title=Ausführen
+
+panelWidth_title=Breite der Panel-Benutzeroberfläche
+panelHeight_title=Höhe des Panel-Benutzeroberfläche


### PR DESCRIPTION
Make German translation usable. Before it was hard to understand the options.
Additionally fixed a problem with "memoryUsageOnTabTitlesPref_title" which preceeded by some text and therefore not shown correctly
